### PR TITLE
Allowing /component/<template_id> to work as a route

### DIFF
--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -38,9 +38,9 @@ module Alephant
       end
 
       def find_id_from_template(template)
-        files = Dir.glob(File.join(Dir.pwd, DEFAULT_LOCATION) + '/**/models/*')
+        files = Dir.glob(BASE_LOCATION + '/**/models/*')
         file = files.select! { |file| file.include? template }.pop
-        result = /#{DEFAULT_LOCATION}\/(\w+)/.match(file)
+        result = /#{BASE_LOCATION}\/(\w+)/.match(file)
         result[1]
       end
 


### PR DESCRIPTION
Allows /component/<template_id> to work - it searches through each queue's model directory attempting to match each model name against the <template_id>, in an attempt to work out which queue the requested template_id is in.
