### PR TITLE
add sinatra reloader

### DIFF
--- a/alephant-preview.gemspec
+++ b/alephant-preview.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
 
   spec.add_runtime_dependency 'sinatra'
+  spec.add_runtime_dependency 'sinatra-reloader'
   spec.add_runtime_dependency 'faraday'
   spec.add_runtime_dependency 'trollop'
   spec.add_runtime_dependency 'rake'

--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -6,6 +6,7 @@ require 'alephant/support/parser'
 require 'alephant/preview/template/base'
 
 require 'sinatra/base'
+require "sinatra/reloader"
 require 'faraday'
 require 'json'
 require 'uri'
@@ -13,6 +14,8 @@ require 'uri'
 module Alephant
   module Preview
     class Server < Sinatra::Base
+      register Sinatra::Reloader
+      also_reload 'components/*/models/*.rb'
 
       BASE_LOCATION = "#{(ENV['BASE_LOCATION'] || Dir.pwd)}/components"
 


### PR DESCRIPTION
![download](https://f.cloud.github.com/assets/803625/2293117/b45ecf22-a066-11e3-8ad2-638d1e606811.jpeg)
- Added sinatra reloader so the server can auto reload when a component model is updated.

@kenoir Could you take a look if we can add this please?

@Guntrisoft @samfrench Please let me know if this works for you?
