### PR TITLE
Fixing issue where incorrect queue was found when component name was a '...

### DIFF
--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -39,7 +39,7 @@ module Alephant
 
       def find_id_from_template(template)
         files = Dir.glob(BASE_LOCATION + '/**/models/*')
-        file = files.select! { |file| file.include? template + '.rb' }.pop
+        file = files.select! { |file| file.include? "/#{template}.rb" }.pop
         result = /#{BASE_LOCATION}\/(\w+)/.match(file)
         result[1]
       end

--- a/lib/alephant/preview/version.rb
+++ b/lib/alephant/preview/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Preview
-    VERSION = "0.0.6"
+    VERSION = "0.0.7"
   end
 end


### PR DESCRIPTION
...substring'

of another component name in a different queue
