### PR TITLE
Fix loss of context

### DIFF
--- a/bin/alephant-preview
+++ b/bin/alephant-preview
@@ -5,8 +5,10 @@ require 'trollop'
 
 root = Pathname.new(__FILE__).dirname.parent
 lib_path = (root + 'lib').realdirpath
+current_dir = File.join(Dir.pwd, "lib")
 
 $LOAD_PATH.unshift(lib_path)
+$LOAD_PATH.unshift(current_dir)
 
 require 'alephant/preview'
 require 'alephant/preview/tasks'

--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -98,8 +98,7 @@ module Alephant
           loader              = Alephant::Preview::FixtureLoader.new(base_path)
           data_mapper_factory = Alephant::Publisher::Request::DataMapperFactory.new(loader, BASE_LOCATION)
           begin
-            mapper              = data_mapper_factory.create(id, {})
-            mapper.data
+            data_mapper_factory.create(id, params).data
           rescue Alephant::Publisher::Request::InvalidApiResponse
             raise "The JSON passed to the data mapper isn't valid"
           rescue StandardError => e


### PR DESCRIPTION
## Problem

The DataMapper wasn't passed the query string parameters. This also inserts the current working directory into Ruby's load path.
## Solution

This... 

![](http://media0.giphy.com/media/WA6BXgYfY7B7i/200.gif)
