### PR TITLE
Add UTF-8 support in source files

### DIFF
--- a/bin/alephant-preview
+++ b/bin/alephant-preview
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env RUBYOPT=-Ku ruby
 
 require 'pathname'
 require 'trollop'


### PR DESCRIPTION
![cat](http://i.imgur.com/bA8Ymyj.gif)

## Problem

JRuby, as a Ruby 1.9 implementation, does not support UTF-8 in source files by default.

## Solution

Providing the `-Ku` parameter via the `RUBYOPT` environmental variable enables this.

