### PR TITLE
Fix fixture loading

### DIFF
--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -31,13 +31,13 @@ module Alephant
         render_preview
       end
 
-      get '/component/:id/:template/?:fixture?' do
+      get '/component/:template/?:fixture?' do
+        params['id'] = find_id_from_template params['template']
+        params['fixture'] = 'responsive' unless params['template']
         render_component
       end
 
-      get '/component/:template/?:fixture?' do
-        params['id'] = find_id_from_template params['template']
-        params['fixture'] = 'responsive'
+      get '/component/:id/:template/?:fixture?' do
         render_component
       end
 

--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -33,7 +33,7 @@ module Alephant
 
       get '/component/:template/?:fixture?' do
         params['id'] = find_id_from_template params['template']
-        params['fixture'] = 'responsive' unless params['template']
+        params['fixture'] = 'responsive' unless params['fixture']
         render_component
       end
 


### PR DESCRIPTION
Fix the component preview url, to be able to load different fixtures.

I moved the component template route above the id template route. I also removed the hard coding of responsive.

![](https://media.giphy.com/media/PdfNwG98g6Sxq/giphy.gif)