### PR TITLE
Update alephant preview to serve batched components

### DIFF
--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -84,9 +84,9 @@ module Alephant
       def render_batch_component
         {
           :component => template,
-          :options => {},
-          :status => 200,
-          :body => render_component
+          :options   => {},
+          :status    => 200,
+          :body      => render_component
         }
       end
 

--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -49,9 +49,10 @@ module Alephant
         batch_components = []
 
         ((JSON.parse(request.body.read, :symbolize_names => true) || {}).fetch(:components, [])).each do |component|
+          options = component.fetch(:options, {}) || {}
           params["template"] = component.fetch(:component)
           params["id"] = find_id_from_template params["template"]
-          params["fixture"] = "responsive"
+          params["fixture"] = options.fetch(:fixture, "responsive") || "responsive"
           batch_components << render_batch_component
         end
 

--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -48,7 +48,7 @@ module Alephant
       post "/components/batch" do
         batch_components = []
 
-        ((JSON.parse(request.body.read, :symbolize_names => true) || {}).fetch(:components, [])).each do |component|
+        batched_components.each do |component|
           options = component.fetch(:options, {}) || {}
           params["template"] = component.fetch(:component)
           params["id"] = find_id_from_template params["template"]
@@ -93,6 +93,15 @@ module Alephant
       end
 
       private
+
+      def request_body
+        JSON.parse(request.body.read, :symbolize_names => true) || {}
+      end
+
+      def batched_components
+        request_body.fetch(:components, [])
+      end
+
       def model
         require model_location
         Alephant::Renderer::Views.get_registered_class(template).new(fixture_data)

--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -27,6 +27,10 @@ module Alephant
 
       BASE_LOCATION = "#{(ENV['BASE_LOCATION'] || Dir.pwd)}/components"
 
+      before do
+        response["Access-Control-Allow-Origin"] = "*"
+      end
+
       get '/preview/:id/:template/:region/?:fixture?' do
         render_preview
       end
@@ -39,6 +43,21 @@ module Alephant
         params['id'] = find_id_from_template params['template']
         params['fixture'] = 'responsive'
         render_component
+      end
+
+      post "/components/batch" do
+        batch_components = []
+
+        ((JSON.parse(request.body.read, :symbolize_names => true) || {}).fetch(:components, [])).each do |component|
+          params["template"] = component.fetch(:component)
+          params["id"] = find_id_from_template params["template"]
+          params["fixture"] = "responsive"
+          batch_components << render_batch_component
+        end
+
+        {
+          :components => batch_components
+        }.to_json
       end
 
       get '/status' do
@@ -61,6 +80,15 @@ module Alephant
 
       def render_component
         view_mapper.generate(fixture_data)[template].render
+      end
+
+      def render_batch_component
+        {
+          :component => template,
+          :options => {},
+          :status => 200,
+          :body => render_component
+        }
       end
 
       private

--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -56,9 +56,7 @@ module Alephant
           batch_components << render_batch_component
         end
 
-        {
-          :components => batch_components
-        }.to_json
+        { :components => batch_components }.to_json
       end
 
       get '/status' do

--- a/spec/fixture_loader_spec.rb
+++ b/spec/fixture_loader_spec.rb
@@ -41,7 +41,7 @@ describe Alephant::Preview::FixtureLoader do
       context 'using incorrect amount of fixtures' do
         it "should raise an exception" do
           (0..2).each { |index| subject.get(uri).body }
-          expect{ subject.get(uri).body }.to raise_error
+          expect{ subject.get(uri).body }.to raise_error(RuntimeError, "There isn't a fixture matching the request call, please add one")
         end
       end
     end

--- a/spec/fixture_loader_spec.rb
+++ b/spec/fixture_loader_spec.rb
@@ -41,7 +41,8 @@ describe Alephant::Preview::FixtureLoader do
       context 'using incorrect amount of fixtures' do
         it "should raise an exception" do
           (0..2).each { |index| subject.get(uri).body }
-          expect{ subject.get(uri).body }.to raise_error(RuntimeError, "There isn't a fixture matching the request call, please add one")
+          expect{ subject.get(uri).body }.to raise_error(RuntimeError,
+            "There isn't a fixture matching the request call, please add one")
         end
       end
     end

--- a/spec/fixture_loader_spec.rb
+++ b/spec/fixture_loader_spec.rb
@@ -38,11 +38,14 @@ describe Alephant::Preview::FixtureLoader do
         end
       end
 
-      context 'using incorrect amount of fixtures' do
+      context "using incorrect amount of fixtures" do
         it "should raise an exception" do
           (0..2).each { |index| subject.get(uri).body }
-          expect{ subject.get(uri).body }.to raise_error(RuntimeError,
-            "There isn't a fixture matching the request call, please add one")
+          expect do
+            subject.get(uri).body
+          end.to raise_error(
+            RuntimeError, "There isn't a fixture matching the request call, please add one"
+          )
         end
       end
     end

--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -84,7 +84,7 @@ describe Alephant::Preview::Server do
           expected = { :components => [ { :component => "bar", :options => {}, :status => 200, :body => "data mapped content\n" } ] }
         end
 
-        context 'using multiple fixtures' do
+        context "using multiple fixtures" do
           let (:id) { "baz" }
 
           expected = { :components => [ { :component => "baz", :options => {}, :status => 200, :body => "multiple endpoint data mapped content\n" } ] }

--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -63,7 +63,16 @@ describe Alephant::Preview::Server do
 
     describe "content" do
       before(:each) do
-        post "/components/batch", { :components => [ { :component => id, :options => { :fixture => id } } ] }.to_json
+        post "/components/batch", {
+          :components => [
+            {
+              :component => id,
+              :options => {
+                :fixture => id
+              }
+            }
+          ]
+        }.to_json
       end
 
       let (:response) { JSON.parse(last_response.body.chomp, :symbolize_names => true) }
@@ -71,7 +80,16 @@ describe Alephant::Preview::Server do
       context "without a data mapper" do
         let(:id) { "foo" }
 
-        expected = { :components => [ { :component => "foo", :options => {}, :status => 200, :body => "content\n" } ] }
+        expected = {
+          :components => [
+            {
+              :component => "foo",
+              :options => {},
+              :status => 200,
+              :body => "content\n"
+            }
+          ]
+        }
 
         specify { expect(response).to eq(expected) }
       end
@@ -81,7 +99,16 @@ describe Alephant::Preview::Server do
         context "using a single fixture" do
           let (:id) { "bar" }
 
-          expected = { :components => [ { :component => "bar", :options => {}, :status => 200, :body => "data mapped content\n" } ] }
+          expected = {
+            :components => [
+              {
+                :component => "bar",
+                :options => {},
+                :status => 200,
+                :body => "data mapped content\n"
+              }
+            ]
+          }
 
           specify { expect(response).to eq(expected) }
         end
@@ -89,7 +116,16 @@ describe Alephant::Preview::Server do
         context "using multiple fixtures" do
           let (:id) { "baz" }
 
-          expected = { :components => [ { :component => "baz", :options => {}, :status => 200, :body => "multiple endpoint data mapped content\n" } ] }
+          expected = {
+            :components => [
+              {
+                :component => "baz",
+                :options => {},
+                :status => 200,
+                :body => "multiple endpoint data mapped content\n"
+              }
+            ]
+          }
 
           specify { expect(response).to eq(expected) }
         end

--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -59,6 +59,42 @@ describe Alephant::Preview::Server do
     end
   end
 
+  describe "component batch endpoint (POST /components/batch" do
+
+    describe "content" do
+      before(:each) do
+        post "/components/batch", { :components => [ { :component => id, :options => { :fixture => id } } ] }.to_json
+      end
+
+      let (:response) { JSON.parse(last_response.body.chomp, :symbolize_names => true) }
+
+      context "without a data mapper" do
+        let(:id) { "foo" }
+
+        expected = { :components => [ { :component => "foo", :options => {}, :status => 200, :body => "content\n" } ] }
+
+        specify { expect(response).to eq(expected) }
+      end
+
+      context "with a data mapper" do
+
+        context "using a single fixture" do
+          let (:id) { "bar" }
+
+          expected = { :components => [ { :component => "bar", :options => {}, :status => 200, :body => "data mapped content\n" } ] }
+        end
+
+        context 'using multiple fixtures' do
+          let (:id) { "baz" }
+
+          expected = { :components => [ { :component => "baz", :options => {}, :status => 200, :body => "multiple endpoint data mapped content\n" } ] }
+
+          specify { expect(response).to eq(expected) }
+        end
+      end
+    end
+  end
+
   describe "status endpoint (GET /status)" do
     before(:each) do
       get "/status"

--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -67,7 +67,7 @@ describe Alephant::Preview::Server do
           :components => [
             {
               :component => id,
-              :options => {
+              :options   => {
                 :fixture => id
               }
             }
@@ -84,9 +84,9 @@ describe Alephant::Preview::Server do
           :components => [
             {
               :component => "foo",
-              :options => {},
-              :status => 200,
-              :body => "content\n"
+              :options   => {},
+              :status    => 200,
+              :body      => "content\n"
             }
           ]
         }
@@ -103,9 +103,9 @@ describe Alephant::Preview::Server do
             :components => [
               {
                 :component => "bar",
-                :options => {},
-                :status => 200,
-                :body => "data mapped content\n"
+                :options   => {},
+                :status    => 200,
+                :body      => "data mapped content\n"
               }
             ]
           }
@@ -120,9 +120,9 @@ describe Alephant::Preview::Server do
             :components => [
               {
                 :component => "baz",
-                :options => {},
-                :status => 200,
-                :body => "multiple endpoint data mapped content\n"
+                :options   => {},
+                :status    => 200,
+                :body      => "multiple endpoint data mapped content\n"
               }
             ]
           }

--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -82,6 +82,8 @@ describe Alephant::Preview::Server do
           let (:id) { "bar" }
 
           expected = { :components => [ { :component => "bar", :options => {}, :status => 200, :body => "data mapped content\n" } ] }
+
+          specify { expect(response).to eq(expected) }
         end
 
         context "using multiple fixtures" do


### PR DESCRIPTION
## Problem

Alephant Preview only serves individual components. To test polling locally, we need to serve batch components.

## Solution

Add batch post endpoint to Alephant Preview.