### PR TITLE
Fix symbol to integer error for batch previewing

### DIFF
--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -49,7 +49,7 @@ module Alephant
         batch_components = []
 
         batched_components.each do |component|
-          options = component.fetch(:options, {}) || {}
+          options = symbolize(component.fetch(:options, {}) || {})
           params["template"] = component.fetch(:component)
           params["id"] = find_id_from_template params["template"]
           params["fixture"] = options.fetch(:fixture, "responsive") || "responsive"
@@ -168,6 +168,9 @@ module Alephant
         Alephant::Renderer::ViewMapper.new(id, BASE_LOCATION)
       end
 
+      def symbolize(hash)
+        Hash[hash.map { |k, v| [k.to_sym, v] }]
+      end
     end
   end
 end

--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -49,7 +49,7 @@ module Alephant
         batch_components = []
 
         batched_components.each do |component|
-          options = symbolize(component.fetch(:options, {}) || {})
+          options = symbolize component.fetch(:options, {})
           params["template"] = component.fetch(:component)
           params["id"] = find_id_from_template params["template"]
           params["fixture"] = options.fetch(:fixture, "responsive") || "responsive"


### PR DESCRIPTION
## Problem

When the PAL makes a component request with options, the options is a hash:
```
{"components":[{"component":"ni_constituency_title","options":{"variant":"N06000006"}}
```

When the PAL makes a component request without options, the options is an array:
```
{"components":[{"component":"ni_editorial_text","options":[]}
``` 

## Solution

Instead of changing the PAL, as the broker can handle `[]` and `{}` for the options, I have moved the same logic to the previewer. The previewer now creates a Hash out of the options, so it always uses a hash.

https://jira.dev.bbc.co.uk/browse/CONNPOL-3055

![](https://media.giphy.com/media/13B4W9UKdMxGTK/giphy.gif)