### PR TITLE
Component not found

### DIFF
--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -63,9 +63,18 @@ module Alephant
         'ok'
       end
 
+      not_found do
+        'Not found'
+      end
+
       def find_id_from_template(template)
         files = Dir.glob(BASE_LOCATION + '/**/models/*')
         file = files.select! { |file| file.include? "/#{template}.rb" }.pop
+
+        if file.nil?
+          halt(404)
+        end
+
         result = /#{BASE_LOCATION}\/(\w+)/.match(file)
         result[1]
       end

--- a/lib/alephant/preview/version.rb
+++ b/lib/alephant/preview/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Preview
-    VERSION = "0.3.8"
+    VERSION = "0.3.9"
   end
 end


### PR DESCRIPTION
![](http://cdn.makeagif.com/media/6-26-2014/MnKAZ1.gif)

If the component name in the URL does not match a ruby file in the model directories then we should return a 404