### PR TITLE
Change sequence id to be a string to fix WEBrick error

### DIFF
--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -128,7 +128,7 @@ module Alephant
       private
 
       def sequence_id
-        Time.now.to_i
+        Time.now.to_s
       end
 
       def get_content_type(content)

--- a/spec/integration/preview_spec.rb
+++ b/spec/integration/preview_spec.rb
@@ -6,7 +6,7 @@ describe Alephant::Preview::Server do
 
   describe "preview endpoint (GET /preview/{id}/{template}/{region}/{fixture})" do
     describe "content" do
-      expected_time = 123_456_789
+      expected_time = "123456789"
 
       context "with valid data" do
         before(:each) do
@@ -39,7 +39,7 @@ describe Alephant::Preview::Server do
 
   describe "component endpoint (GET /component/{id}/{template}/{fixture})" do
     describe "content" do
-      expected_time = 123_456_789
+      expected_time = "123456789"
 
       before(:each) do
         allow(Time).to receive(:now).and_return(expected_time)
@@ -117,7 +117,7 @@ describe Alephant::Preview::Server do
 
   describe 'component batch endpoint (GET /components/batch?components[#{id}]=#{id})' do
     describe "content" do
-      expected_time = 123_456_789
+      expected_time = "123456789"
 
       before(:each) do
         allow(Time).to receive(:now).and_return(expected_time)
@@ -202,7 +202,7 @@ describe Alephant::Preview::Server do
 
   describe "component batch endpoint (POST /components/batch" do
     describe "content" do
-      expected_time = 123_456_789
+      expected_time = "123456789"
 
       before(:each) do
         allow(Time).to receive(:now).and_return(expected_time)


### PR DESCRIPTION
Change sequence id to be a string to fix WEBrick error

```
[2016-06-09 15:16:17] ERROR NoMethodError: undefined method `split' for 1465481777:Fixnum
	/Users/FrencS03/.gem/jruby/1.9.3/gems/rack-1.6.4/lib/rack/handler/webrick.rb:99:in `service'
	/Users/FrencS03/.gem/jruby/1.9.3/gems/rack-1.6.4/lib/rack/utils.rb:490:in `each'
	org/jruby/RubyHash.java:1341:in `each'
	/Users/FrencS03/.gem/jruby/1.9.3/gems/rack-1.6.4/lib/rack/utils.rb:489:in `each'
	/Users/FrencS03/.gem/jruby/1.9.3/gems/rack-1.6.4/lib/rack/handler/webrick.rb:91:in `service'
	/opt/rubies/jruby-1.7.17/lib/ruby/1.9/webrick/httpserver.rb:138:in `service'
	/opt/rubies/jruby-1.7.17/lib/ruby/1.9/webrick/httpserver.rb:94:in `run'
	/opt/rubies/jruby-1.7.17/lib/ruby/1.9/webrick/server.rb:191:in `start_thread'
192.168.192.1 - - [09/Jun/2016:15:16:17 BST] "GET /component/eu_ref_turnout HTTP/1.1" 500 330
```

Looking into this, WEBrick loops over the headers and calls split on them. Only a string allows split.

> https://github.com/rack/rack/blob/master/lib/rack/handler/webrick.rb#L97