### PR TITLE
Fix timestamp returned to be integer as string

### DIFF
--- a/lib/alephant/preview/server.rb
+++ b/lib/alephant/preview/server.rb
@@ -128,7 +128,7 @@ module Alephant
       private
 
       def sequence_id
-        Time.now.to_s
+        Time.now.to_i.to_s
       end
 
       def get_content_type(content)


### PR DESCRIPTION
Fix timestamp returned to be integer as string